### PR TITLE
Fix for decoding wav files with info tags

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -523,6 +523,14 @@ func newDecoder(r interface{}) (audio.Decoder, error) {
 				SampleRate: int(c16.SamplesPerSec),
 			}
 
+		case "LIST":
+			// Read and skip info tag
+			var infotag [4]byte
+			err = d.bRead(&infotag, binary.Size(infotag))
+			if err != nil {
+				return nil, err
+			}
+
 		case "fact":
 			// We need to scan fact chunk first.
 			var fact factChunk


### PR DESCRIPTION
Some utils (ffmpeg for example) adds additional info into the file. Without this fix we always got EOF error for files with info.

![scr](https://cloud.githubusercontent.com/assets/182020/6838643/fd38249c-d36d-11e4-8e70-77209a15d7cc.png)