### PR TITLE
Fix for wav files with info tags

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -523,6 +523,11 @@ func newDecoder(r interface{}) (audio.Decoder, error) {
 				SampleRate: int(c16.SamplesPerSec),
 			}
 
+		case "LIST":
+			// Read and skip info tags
+			var info []byte = make([]byte, length)
+			d.bRead(&info, int(length))
+
 		case "fact":
 			// We need to scan fact chunk first.
 			var fact factChunk


### PR DESCRIPTION
Some utils (ffmpeg for example) adds additional info into the file. Without this fix we always got EOF error for files with info.

![scr](https://cloud.githubusercontent.com/assets/182020/6845439/d1962052-d3c5-11e4-97ae-cc98f09d1e7a.png)
