### PR TITLE
Added Config.BPS support

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -86,6 +86,7 @@ func TestDecodeFloat32(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        32,
 		},
 		start: audio.F32Samples{0, 0, 9.682657e-08, 3.3106906e-10, 9.845178e-07, 3.9564156e-09, 3.711236e-06, 1.869304e-08, 8.562939e-06, 5.7355663e-08, 1.4786613e-05, 1.3752022e-07, 2.1342606e-05, 2.8124632e-07, 2.7840168e-05},
 	})
@@ -98,6 +99,7 @@ func TestDecodeFloat64(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        64,
 		},
 		start: audio.F64Samples{0, 0, 9.682656809673063e-08, 3.31069061054734e-10, 9.845177828537999e-07, 3.9564156395499595e-09, 3.7112361042090924e-06, 1.8693040004791328e-08, 8.56293900142191e-06, 5.7355663329872186e-08, 1.4786613064643461e-05, 1.375202174358492e-07, 2.134260648745112e-05, 2.812463151258271e-07, 2.7840167604153976e-05},
 	})
@@ -110,6 +112,7 @@ func TestDecodeUInt8(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        8,
 		},
 		start: audio.PCM8Samples{128, 128, 128, 128, 128, 128, 127, 127, 128, 128, 128, 128, 128, 127, 128},
 	})
@@ -122,6 +125,7 @@ func TestDecodeInt16(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        16,
 		},
 		start: audio.PCM16Samples{0, 0, 0, 0, 1, 0, -1, 0, 1, -1, -1, 2, 3, -2, 0},
 	})
@@ -134,6 +138,7 @@ func TestDecodeInt24(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        24,
 		},
 		start: audio.PCM32Samples{0, 0, 0, 0, 8, 0, 31, 0, 71, 0, 124, 1, 179, 2, 233},
 	})
@@ -146,6 +151,7 @@ func TestDecodeInt32(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        32,
 		},
 		start: audio.PCM32Samples{0, 0, 208, 1, 2114, 8, 7970, 40, 18389, 123, 31754, 295, 45833, 604, 59786},
 	})
@@ -158,6 +164,7 @@ func TestDecodeALaw(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        8,
 		},
 		start: audio.ALawSamples{213, 213, 213, 213, 213, 213, 213, 213, 213, 213, 213, 213, 213, 85, 213},
 	})
@@ -170,6 +177,7 @@ func TestDecodeMuLaw(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        8,
 		},
 		start: audio.MuLawSamples{127, 255, 255, 255, 127, 127, 255, 255, 127, 127, 255, 255, 127, 127, 255},
 	})
@@ -182,6 +190,7 @@ func TestDecodeListData(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 16000,
 			Channels:   1,
+			BPS:        16,
 		},
 		start: audio.PCM16Samples{-397, -140, -737, 907, -66, -552, 584, 40, 322, 458, -624, -46, -52, 180, -28},
 	})

--- a/decoder.go
+++ b/decoder.go
@@ -521,6 +521,7 @@ func newDecoder(r interface{}) (audio.Decoder, error) {
 			d.config = &audio.Config{
 				Channels:   int(c16.Channels),
 				SampleRate: int(c16.SamplesPerSec),
+				BPS:        int(d.bitsPerSample),
 			}
 
 		case "LIST":

--- a/encode_test.go
+++ b/encode_test.go
@@ -142,6 +142,7 @@ func TestEncodeFloat32(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        16,
 		},
 		format: audio.F32Samples{},
 	})
@@ -152,6 +153,7 @@ func TestEncodeFloat64(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        16,
 		},
 		format: audio.F64Samples{},
 	})
@@ -162,6 +164,7 @@ func TestEncodeUInt8(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        16,
 		},
 		format: audio.PCM8Samples{},
 	})
@@ -172,6 +175,7 @@ func TestEncodeInt16(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        16,
 		},
 		format: audio.PCM16Samples{},
 	})
@@ -182,6 +186,7 @@ func TestEncodeInt32(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        16,
 		},
 		format: audio.PCM32Samples{},
 	})
@@ -192,6 +197,7 @@ func TestEncodeALaw(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        16,
 		},
 		format: audio.ALawSamples{},
 	})
@@ -202,6 +208,7 @@ func TestEncodeMuLaw(t *testing.T) {
 		Config: audio.Config{
 			SampleRate: 44100,
 			Channels:   2,
+			BPS:        16,
 		},
 		format: audio.MuLawSamples{},
 	})

--- a/encoder.go
+++ b/encoder.go
@@ -36,7 +36,13 @@ func NewEncoder(w io.WriteSeeker, conf audio.Config) (audio.Encoder, error) {
 	// Write WAV file header to w, based on the audio configuration.
 	// TODO(u): Add output support for additional audio sample format; instead of
 	// only using 16-bit PCM.
-	enc := &encoder{bw: bufio.NewWriter(w), ws: w, conf: conf, bps: 16}
+	var bps uint8 = 16
+
+	if conf.BPS != 0 {
+		bps = uint8(conf.BPS)
+	}
+
+	enc := &encoder{bw: bufio.NewWriter(w), ws: w, conf: conf, bps: bps}
 	err := enc.writeHeader()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi, I'm working on waveform generator and use azul3d/audio packages for working with wav files. For working with waveform data we use https://github.com/bbcrd/peaks.js For proper waveform rendering we must export BPS (_bits per sample_) info, but currently this info is only accessible inside package.

I made this changes (_as well as to audio and audio-flac packages_) for export bps data to config structure. All changes backward compatible with previous version.